### PR TITLE
Duplicate buffer for thread-safe aliasing.

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
+++ b/java/core/src/main/java/com/google/protobuf/CodedInputStream.java
@@ -1306,7 +1306,7 @@ public abstract class CodedInputStream {
     }
 
     private UnsafeDirectNioDecoder(ByteBuffer buffer, boolean immutable) {
-      this.buffer = buffer;
+      this.buffer = buffer.duplicate();  // modified in #slice()
       address = UnsafeUtil.addressOffset(buffer);
       limit = address + buffer.limit();
       pos = address + buffer.position();

--- a/java/core/src/test/java/com/google/protobuf/CodedInputStreamTest.java
+++ b/java/core/src/test/java/com/google/protobuf/CodedInputStreamTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.primitives.Bytes;
 import map_test.MapTestProto.MapContainer;
+import org.junit.Ignore;
 import protobuf_unittest.UnittestProto.BoolMessage;
 import protobuf_unittest.UnittestProto.Int32Message;
 import protobuf_unittest.UnittestProto.Int64Message;
@@ -28,6 +29,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -1403,6 +1406,41 @@ public class CodedInputStreamTest {
       result.position(bytesLength - 1);
       assertWithMessage(inputType.name()).that(result.get()).isEqualTo((byte) 89);
     }
+  }
+
+  @Ignore("for demonstrational purpose only")
+  @Test
+  public void testByteBufferInputStreamReadBytesWithAliasConcurrently() throws Exception {
+    ByteBuffer input = ByteBuffer.allocateDirect(128);
+    input.put((byte) 127);
+    for (int i = 0; i < 127; i++) input.put((byte) i);
+    input.flip();
+
+    Supplier<Integer> embeddedSize =
+        () -> {
+          try {
+            final CodedInputStream inputStream = CodedInputStream.newInstance(input, true);
+            inputStream.enableAliasing(true);
+            return inputStream.readBytes().size();
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        };
+
+    assertThat(embeddedSize.get()).isEqualTo(127);
+
+    // Concurrent reader should have no impact ...
+    int iterations = 100000;
+    new Thread(
+            () -> {
+              for (int i = 0; i < iterations; i++) embeddedSize.get();
+            })
+        .start();
+
+    // ... but reliably fails the check:
+    //   expected: 127
+    //   but was : 0
+    for (int i = 0; i < iterations; i++) assertThat(embeddedSize.get()).isEqualTo(127);
   }
 
   @Test


### PR DESCRIPTION
Fixes thread-safety issue #10697: UnsafeDirectNioDecoder modifies shared buffer instance.